### PR TITLE
Convert blog from Jekyll to DomStack (@domstack/static)

### DIFF
--- a/domstack-issues/02-document-global-data-api.md
+++ b/domstack-issues/02-document-global-data-api.md
@@ -1,4 +1,4 @@
-# Document `global.data.js` PageData API and `.vars` getter behavior
+# Document `global.data.js` caveats: vars getter, error handling, and raw content
 
 `Labels: documentation, dx`
 
@@ -6,226 +6,51 @@
 
 ## Problem
 
-The `global.data.js` file is one of the most powerful features in DomStack -- it aggregates page data to build feeds, archives, tag indexes, search data, and more. Yet its documentation is minimal to nonexistent. Users must read the internal source code (`lib/build-pages/page-data.js`, `lib/build-pages/resolve-vars.js`) to understand:
+The DomStack README has a dedicated `global.data.js` section that documents the feature's purpose, function signature, type annotations (`GlobalDataFunction<T>`, `AsyncGlobalDataFunction<T>`), and a working example. The key properties are also listed:
 
-1. What properties are available on the `pages` array elements (`PageData` instances)
-2. That `.vars` is a **computed getter** that merges four variable sources on every access
-3. That `.vars` can **throw** if a page module has errors (e.g., syntax errors in `page.vars.js`)
-4. That `.vars.content` for markdown pages is **raw markdown**, not rendered HTML
-5. The variable merge order and its precedence rules
-6. That the return value is merged into every page's `vars` (meaning `global.data.js` output is available in layouts, page functions, and templates)
+> - Receives fully resolved `PageData[]`
+> - Runs inside the worker process
+> - Skipped entirely if no `global.data.*` file exists
+> - Changes to `global.data.*` trigger a full page rebuild
 
-Without documentation, every DomStack user writing a `global.data.js` must discover these behaviors through trial, error, and source diving.
+However, several important **runtime caveats** are not covered. Users must discover these through source diving or trial and error:
 
----
+1. That `.vars` is a **computed getter** that performs a fresh 4-way merge on every access
+2. That `.vars` can **throw** if a page module has errors (syntax errors, missing dependencies)
+3. That `.vars.content` for markdown pages is **raw markdown**, not rendered HTML
+4. That `renderInnerPage()` is not available in `global.data.js` (it runs before the rendering stage)
 
-## Current behavior
-
-A user creates `src/global.data.js` and receives a `{ pages }` param with no guidance on what `pages` contains:
-
-```js
-// src/global.data.js -- what a new user writes
-export default function globalData ({ pages }) {
-  // What properties does pages[0] have?
-  // What is pages[0].pageInfo? What fields does it contain?
-  // What is pages[0].vars? Is it a plain object or something else?
-  // Is pages[0].vars.content rendered HTML or raw markdown?
-  // Can pages[0].vars throw? Under what conditions?
-  // What does the return value do? Where does it end up?
-}
-```
-
-The user must read `lib/build-pages/page-data.js` to find the `vars` getter implementation:
-
-```js
-// From @domstack/static/lib/build-pages/page-data.js (actual source)
-get vars () {
-  if (!this.#initialized) throw new Error('Initialize PageData before accessing vars')
-  const { globalVars, globalDataVars, pageVars, builderVars } = this
-  return {
-    ...globalVars,
-    ...globalDataVars,
-    ...pageVars,
-    ...builderVars,
-  }
-}
-```
-
-This reveals critical information that should be in the docs: `vars` performs a fresh object spread on every access, combining four separate sources.
+These caveats have real consequences for build reliability and performance.
 
 ---
 
-## Expected behavior
+## What the README already covers
 
-A dedicated "Global Data" section in the documentation should explain the full API surface, including caveats, with enough detail that users never need to read the source.
+The README's `global.data.js` section documents:
 
----
-
-## Workaround
-
-Users read the source code, copy patterns from example sites, and discover caveats the hard way. This codebase's `src/global.data.js` demonstrates several learned-the-hard-way patterns:
-
-<details>
-<summary>Full src/global.data.js from this codebase (73 lines)</summary>
-
-```js
-/**
- * Aggregate page data for indexes, feeds, and archives.
- * Pages are DomStack PageData objects with .pageInfo and .vars properties.
- *
- * @param {{ pages: Array<{ pageInfo: { path: string, outputRelname: string },
- *           vars: Record<string, unknown> }> }} options
- * @returns {Record<string, unknown>}
- */
-export default function globalData ({ pages }) {
-  // Filter pages that are blog posts (have a date and article layout)
-  const allPosts = pages
-    .filter(p => {
-      try {
-        return p.vars && p.vars.layout === 'article' && p.vars.date;
-      } catch {
-        return false;
-      }
-    })
-    .map(p => {
-      const vars = p.vars;  // Cache the getter result
-      const pagePath = p.pageInfo.path;
-      const pageUrl = pagePath ? '/' + pagePath + '/' : '/';
-
-      return {
-        title: vars.title || '',
-        date: vars.date,
-        lang: vars.lang,
-        category: vars.category,
-        content: vars.content || '',
-        path: pagePath,
-        pageUrl,
-        ...Object.fromEntries(
-          Object.entries(vars).filter(([k]) => k.startsWith('mf-'))
-        ),
-        tags: vars.tags,
-        persontags: vars.persontags,
-        submitto: vars.submitto,
-      };
-    })
-    .sort((a, b) =>
-      new Date(b.date).getTime() - new Date(a.date).getTime()
-    );
-
-  const blogPosts = allPosts.filter(p => !p.category);
-  const socialPosts = allPosts.filter(p => p.category === 'social');
-  const linkPosts = allPosts.filter(p => p.category === 'links');
-
-  const recentPosts = blogPosts.slice(0, 10);
-  const recentEnglishPosts = blogPosts.filter(p => p.lang === 'en').slice(0, 10);
-  const recentLinks = linkPosts.slice(0, 10);
-
-  const postsByYear = {};
-  for (const post of blogPosts) {
-    const year = new Date(post.date).getFullYear().toString();
-    if (!postsByYear[year]) postsByYear[year] = [];
-    postsByYear[year].push(post);
-  }
-
-  return {
-    allPosts, blogPosts, socialPosts, linkPosts,
-    recentPosts, recentEnglishPosts, recentLinks, postsByYear,
-  };
-}
-```
-
-</details>
-
-Note three patterns this code had to discover without documentation:
-
-1. **`try/catch` around `p.vars`** -- because the getter can throw if a page module is broken
-2. **`const vars = p.vars`** -- caching the getter result to avoid redundant merges
-3. **`vars.content` used as raw text** -- because it is raw markdown, not rendered HTML
+- **Purpose**: "runs once per build, after all pages are initialized and before rendering begins"
+- **Input**: "receives a fully resolved `PageData[]` array"
+- **Output**: "returns an object that is stamped onto every page's vars"
+- **Types**: `GlobalDataFunction<T>` and `AsyncGlobalDataFunction<T>`
+- **Example**: A complete example showing page filtering, sorting, and computed output
+- **Variable merge order**: The Variables section documents that `vars` is a merge of "global.vars + global.data + page.vars + builder vars" (with later sources taking precedence)
 
 ---
 
-## Proposed solution
+## What's missing: runtime caveats
 
-Add a "Global Data" section to the DomStack documentation covering the following content.
+### 1. `page.vars` is a computed getter
 
-### Section 1: Overview and function signature
+The `.vars` property is not a plain object. It performs a fresh `{ ...globalVars, ...globalDataVars, ...pageVars, ...builderVars }` spread on every access. This means:
 
-```markdown
-## global.data.js / global.data.ts
-
-The optional `global.data.js` file in your `src/` directory exports a default function
-that receives all resolved pages and returns an object of additional variables. These
-variables are merged onto **every page's** `vars` object, making them available in
-layouts, page functions, and templates.
-
-This is the primary mechanism for building:
-- Blog post indexes and archives
-- RSS/Atom feed data
-- Tag clouds and category pages
-- Site-wide navigation data
-- Search indexes
-
-### Function signature
-
-The default export receives a single object:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pages`   | `PageData[]` | Array of all resolved page objects in the site |
-
-The return value (sync or async) is an object whose keys become available on
-every page's `vars`:
-
-| Return | Type | Description |
-|--------|------|-------------|
-| (return value) | `Record<string, any>` | Merged into `vars` at position 2 in the merge order |
-```
-
-### Section 2: PageData properties reference
-
-```markdown
-### PageData properties
-
-Each element in the `pages` array is a `PageData` instance with these properties:
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `pageInfo` | `PageInfo` | Static metadata about the page file |
-| `pageInfo.path` | `string` | URL path segment, e.g., `"2015/01/my-post"` |
-| `pageInfo.type` | `"js" \| "md" \| "html"` | Page builder type |
-| `pageInfo.draft` | `boolean` | Whether this is a draft page |
-| `pageInfo.outputName` | `string` | Output filename, usually `"index.html"` |
-| `pageInfo.outputRelname` | `string` | Relative output path, e.g., `"2015/01/my-post/index.html"` |
-| `pageInfo.pageFile` | `PageFile` | File system info (root, filepath, relname, basename, parentName) |
-| `pageInfo.pageStyle` | `PageFileAsset \| undefined` | Associated `style.css` if present |
-| `pageInfo.clientBundle` | `PageFileAsset \| undefined` | Associated client JS bundle if present |
-| `pageInfo.pageVars` | `PageFileAsset \| undefined` | Associated `page.vars.js` if present |
-| `pageInfo.workers` | `Record<string, PageFileAsset> \| undefined` | Web worker files |
-| `vars` | `object` (getter) | Merged page variables -- see caveats below |
-| `styles` | `string[]` | Stylesheet paths for this page (global + page-specific) |
-| `scripts` | `string[]` | Script paths for this page (global + page-specific) |
-| `renderInnerPage({ pages })` | `Promise<string>` | Render this page's inner content (available in templates, not global.data) |
-```
-
-### Section 3: Caveats (critical)
-
-```markdown
-### Caveats
-
-#### 1. `page.vars` is a computed getter
-
-The `.vars` property is **not a plain object**. It is a getter that performs a fresh
-`{ ...globalVars, ...globalDataVars, ...pageVars, ...builderVars }` spread on every
-access. This means:
-
-- **Cache the result** if you need multiple properties from the same page:
+- **Cache the result** when reading multiple properties:
 
   ```js
-  // GOOD -- single getter invocation, destructure from the cached result
+  // GOOD -- single getter invocation
   const vars = page.vars;
   const { title, date, lang, category } = vars;
 
-  // AVOID -- triggers a fresh 4-way merge on each property access
+  // AVOID -- triggers a fresh 4-way merge on each access
   const title = page.vars.title;
   const date = page.vars.date;
   const lang = page.vars.lang;
@@ -233,11 +58,9 @@ access. This means:
 
 - For large sites with hundreds of pages, caching can noticeably reduce build time.
 
-#### 2. `page.vars` may throw
+### 2. `page.vars` may throw
 
-If the underlying `page.vars.js` module has a syntax error, missing import, or
-runtime exception, accessing `.vars` will throw. When iterating all pages,
-**always wrap in try/catch** for resilience:
+If the underlying `page.vars.js` module has a syntax error, missing import, or runtime exception, accessing `.vars` will throw. When iterating all pages, **always wrap in try/catch**:
 
   ```js
   const posts = pages.filter(p => {
@@ -249,92 +72,57 @@ runtime exception, accessing `.vars` will throw. When iterating all pages,
   });
   ```
 
-This is not a theoretical concern -- it happens during development when pages are
-work-in-progress.
+This is not theoretical -- it happens during development when pages are work-in-progress.
 
-#### 3. `page.vars.content` is raw source, not rendered HTML
+### 3. `page.vars.content` is raw source, not rendered HTML
 
-For markdown pages, `vars.content` is the **raw markdown string** as read from the
-`.md` file. It is not rendered HTML. To get rendered HTML, use `renderInnerPage()`
-in a template (see issue #03), or render it yourself with a markdown library.
+For markdown pages, `vars.content` is the **raw markdown string** as read from the `.md` file. To get rendered HTML, use `renderInnerPage()` in a template (see issue #03).
 
-#### 4. `renderInnerPage()` is not available in global.data.js
+### 4. `renderInnerPage()` is not available in `global.data.js`
 
-The `renderInnerPage()` method exists on `PageData` objects, but it is designed for
-use in templates, which run after global data resolution. Calling it in `global.data.js`
-may not work as expected because the build pipeline has not yet reached the rendering
-stage.
-```
+`global.data.js` runs before the rendering stage. The `renderInnerPage()` method on `PageData` objects is designed for templates, which run after global data resolution.
 
-### Section 4: Variable merge order
+---
 
-```markdown
-### Variable merge order (later wins)
+## Workaround
 
-When `page.vars` is accessed, four sources are merged via object spread. Later
-sources override earlier ones for the same key:
+Users discover these patterns through source diving. This codebase's `src/global.data.js` demonstrates all three defensive patterns:
 
-| Priority | Source | Set by | Example |
-|----------|--------|--------|---------|
-| 1 (lowest) | `global.vars.js` | Site-wide defaults | `{ siteUrl: '...', blogName: '...' }` |
-| 2 | `global.data.js` return | Computed global data (this file) | `{ recentPosts: [...], postsByYear: {...} }` |
-| 3 | `page.vars.js` / `export const vars` | Per-page overrides | `{ layout: 'article', title: 'My Post' }` |
-| 4 (highest) | Builder vars | Page builder (md, js, html) | `{ content: '...' }` for markdown pages |
-
-This means a page's `title` set in `page.vars.js` overrides anything in `global.vars.js`,
-and `content` set by the markdown builder overrides everything.
-```
-
-### Section 5: Practical example
-
-```markdown
-### Complete example
-
-  ```js
-  // src/global.data.js
-  /** @type {import('@domstack/static').GlobalDataFunction} */
-  export default function globalData ({ pages }) {
-    const posts = pages
-      .filter(p => {
-        try { return p.vars.layout === 'article' && p.vars.date; }
-        catch { return false; }
-      })
-      .map(p => {
-        const vars = p.vars;
-        return {
-          title: vars.title,
-          date: vars.date,
-          path: p.pageInfo.path,
-          pageUrl: '/' + p.pageInfo.path + '/',
-        };
-      })
-      .sort((a, b) => new Date(b.date) - new Date(a.date));
-
-    return {
-      recentPosts: posts.slice(0, 10),
-      postsByYear: Object.groupBy(posts, p =>
-        new Date(p.date).getFullYear().toString()
-      ),
-    };
-  }
-  ```
-
-These returned properties (`recentPosts`, `postsByYear`) are then available in
-every page function, layout, and template via `vars.recentPosts`,
-`vars.postsByYear`, etc.
+```js
+export default function globalData ({ pages }) {
+  const allPosts = pages
+    .filter(p => {
+      try {                                    // Caveat 2: vars can throw
+        return p.vars && p.vars.layout === 'article' && p.vars.date;
+      } catch {
+        return false;
+      }
+    })
+    .map(p => {
+      const vars = p.vars;                     // Caveat 1: cache the getter
+      return {
+        title: vars.title || '',
+        content: vars.content || '',           // Caveat 3: raw markdown
+        // ...
+      };
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  // ...
+}
 ```
 
 ---
 
-## Alternatives considered
+## Proposed solution
 
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Docs section (proposed)** | Covers all caveats, easily discoverable | Requires ongoing maintenance as API evolves |
-| **JSDoc on the `PageData` class only** | Closer to source of truth | Users still must find and read source; misses caveats like try/catch and merge order |
-| **Guided example in project scaffold** | Immediate on-boarding | Doesn't help users who add `global.data.js` later |
+Add a "Caveats" or "Important notes" subsection to the existing `global.data.js` documentation covering:
 
-A docs section is the best first step; once issue #01 lands (type exports), the docs can link directly to importable types.
+1. Vars getter behavior (cache the result)
+2. Error handling (wrap in try/catch)
+3. Raw content (markdown pages provide raw source, not rendered HTML)
+4. Rendering availability (renderInnerPage is for templates, not global.data)
+
+This is a small addition to the existing documentation section -- not a new section from scratch.
 
 ---
 
@@ -348,10 +136,8 @@ In this codebase, `global.data.js` produces the data consumed by **6 different f
 | `src/archive/page.js` | `vars.postsByYear` |
 | `src/links/page.js` | `vars.linkPosts` |
 | `src/social/page.js` | `vars.socialPosts` |
-| `src/feeds.template.js` | Re-derives post data (because templates receive `vars` from `global.vars` only, not `global.data`) |
+| `src/feeds.template.js` | Re-derives post data (because templates receive `vars` from `global.vars` only, not `global.data` -- see issue #09) |
 | `src/sitemap.xml.template.js` | Iterates `pages` directly for URL generation |
-
-The fact that `feeds.template.js` must re-derive post filtering and sorting logic that already exists in `global.data.js` hints at a documentation gap -- users may not understand which vars are available where.
 
 ---
 
@@ -359,4 +145,5 @@ The fact that `feeds.template.js` must re-derive post filtering and sorting logi
 
 - **#01** -- Exporting `PageData` and `PageInfo` types would let the docs reference importable types and give users autocompletion for the properties documented here.
 - **#03** -- Rendered content availability is a key caveat of `global.data.js`; that issue covers the `renderInnerPage()` API in detail.
-- **#05** -- Template return types documentation should cross-reference global data, since templates receive `pages` and `vars` but with different merge semantics.
+- **#07** -- The vars getter error behavior described here is the same issue addressed by #07's proposal to wrap the getter with better error messages.
+- **#09** -- Templates not receiving `global.data.js` output forces `feeds.template.js` to re-derive all the data that `global.data.js` already computes.

--- a/domstack-issues/03-rendered-content-in-templates.md
+++ b/domstack-issues/03-rendered-content-in-templates.md
@@ -1,4 +1,4 @@
-# Provide rendered HTML content in `global.data.js` and document `renderInnerPage()` API
+# Formally document `renderInnerPage()` API and rendered content architecture
 
 `Labels: enhancement, documentation, dx`
 
@@ -6,238 +6,156 @@
 
 ## Problem
 
-DomStack users frequently need access to **rendered HTML content** from other pages -- for RSS/Atom feeds, search indexes, archive previews, and more. The `renderInnerPage()` method on `PageData` objects provides this capability in templates, but it is undocumented and unavailable in `global.data.js`.
+The `renderInnerPage()` method on `PageData` objects is the primary mechanism for accessing **rendered HTML content** from other pages — essential for RSS/Atom feeds, search indexes, and archive previews. The method is demonstrated in the README's "RSS Feed Template Example" but lacks formal dedicated documentation explaining its behavior, parameters, return value, and limitations.
 
-This creates a two-tier experience:
-- **Templates** can call `page.renderInnerPage({ pages })` to get rendered HTML (works today, undocumented)
-- **`global.data.js`** has no way to access rendered content at all, because it runs before the rendering stage of the build pipeline
-
-Users who need rendered content in page functions (e.g., for archive pages that show post excerpts) must work around this by duplicating rendering logic or restructuring their data flow.
+This creates a discoverability gap: users who read the template documentation linearly may encounter `renderInnerPage()` in the RSS example, but there is no reference section explaining:
+- What the method does (renders inner page content without layout wrapper)
+- That `renderFullPage()` also exists (renders with layout applied)
+- That both methods require passing the full `pages` array
+- Performance considerations (parallel rendering, caching)
+- That these methods are designed for templates, not `global.data.js`
 
 ---
 
-## Current behavior
+## What the README already covers
 
-### In templates: `renderInnerPage()` works but is undocumented
-
-The `PageData` class exposes `renderInnerPage()` as a public method:
+The README's "RSS Feed Template Example" shows a working usage of `renderInnerPage()`:
 
 ```typescript
-// From @domstack/static/lib/build-pages/page-data.d.ts
-class PageData<T, U, V> {
-  renderInnerPage({ pages }: { pages: PageData<T, U, V>[] }): Promise<string>;
-  renderFullPage({ pages }: { pages: PageData<T, U, V>[] }): Promise<any>;
-  // ...
-}
-```
-
-The implementation (from `page-data.js`) shows it invokes the page's builder and layout function:
-
-```js
-async renderInnerPage ({ pages }) {
-  if (!this.#initialized) throw new Error('Must be initialized before rendering inner pages')
-  const { pageInfo, styles, scripts, vars, builderOptions, workers } = this
-  if (!pageInfo) throw new Error('A page is required to render')
-  const builder = pageBuilders[pageInfo.type]
-  const { pageLayout } = await builder({ pageInfo, options: builderOptions })
-  const results = await pageLayout({ vars, styles, scripts, pages, page: pageInfo, workers })
-  return results
-}
-```
-
-This codebase uses it successfully in `src/feeds.template.js` to render post content for Atom feeds:
-
-<details>
-<summary>Working renderInnerPage() usage from src/feeds.template.js</summary>
-
-```js
-export default async function * feedsTemplate ({ pages, vars }) {
-  const siteUrl = vars.siteUrl;
-  // ...
-
-  // Build page index for O(1) lookup
-  const pagesByPath = new Map(pages.map(p => [p.pageInfo.path, p]));
-
-  // Pre-render all unique feed posts in parallel
-  const allFeedPosts = [...new Map(
-    [...recentPosts, ...recentEnglishPosts, ...recentLinks]
-      .map(p => [p.path, p])
-  ).values()];
-
-  const renderCache = new Map();
-  await Promise.all(allFeedPosts.map(async (post) => {
-    const page = pagesByPath.get(post.path);
-    const html = page ? await page.renderInnerPage({ pages }) : '';
-    renderCache.set(post.path, html);
-  }));
-
-  // Use cached rendered HTML in feed entries
-  function buildFeed ({ posts, selfUrl, subtitle }) {
-    const entries = posts.map(post => {
-      const html = renderCache.get(post.path) || '';
-      return renderRssEntry({ content: html, post, siteUrl });
-    });
-    // ...
+items: await pMap(blogPosts, async (page) => {
+  return {
+    date_published: page.vars['publishDate'],
+    title: page.vars['title'],
+    url: `${homePageUrl}/${page.pageInfo.path}/`,
+    id: `${homePageUrl}/${page.pageInfo.path}/#${page.vars['publishDate']}`,
+    content_html: await page.renderInnerPage({ pages })
   }
-
-  yield { outputName: 'all.xml', content: await buildFeed({ /* ... */ }) };
-  yield { outputName: 'english.xml', content: await buildFeed({ /* ... */ }) };
-  yield { outputName: 'links/all.xml', content: await buildFeed({ /* ... */ }) };
-}
+}, { concurrency: 4 })
 ```
 
-</details>
-
-This pattern works well, but the user must discover `renderInnerPage()` by reading the type definitions or source code. There is no documentation explaining:
-- That the method exists
-- That it requires passing the full `pages` array
-- That it returns the inner page content (without the layout wrapper)
-- That `renderFullPage()` also exists (returns content with layout applied)
-- Performance considerations (parallel rendering, caching)
-- That it only works in templates, not in `global.data.js`
+This demonstrates the method signature and shows it being called with `{ pages }` and used in a concurrency-limited parallel context. The `global.data.js` section also documents that it "runs once per build, after all pages are initialized and **before rendering begins**" — implicitly explaining why `renderInnerPage()` is a template-stage API.
 
 ---
 
-### In `global.data.js`: no access to rendered content
+## What's missing
 
-`global.data.js` runs during the `resolveGlobalData()` phase, which occurs **before** page rendering. At this point, `PageData` objects are initialized but their `renderInnerPage()` method depends on the build pipeline state that may not be fully ready.
+### 1. Formal API reference for `renderInnerPage()` and `renderFullPage()`
 
-This means that code like the following -- which would be the natural approach -- does not work:
+A brief reference section documenting:
 
-```js
-// src/global.data.js -- THIS DOES NOT WORK
-export default async function globalData ({ pages }) {
-  const posts = pages.filter(p => {
-    try { return p.vars.layout === 'article'; }
-    catch { return false; }
-  });
-
-  // Cannot reliably call renderInnerPage() here -- we're in the wrong pipeline stage
-  for (const post of posts) {
-    const html = await post.renderInnerPage({ pages }); // May fail or produce incomplete results
-  }
-}
+```typescript
+// Available on PageData objects in templates
+page.renderInnerPage({ pages }): Promise<string>   // Content without layout
+page.renderFullPage({ pages }): Promise<any>        // Content with layout applied
 ```
 
-As a result, `global.data.js` can only access `vars.content`, which for markdown pages is the **raw markdown source**, not rendered HTML. Pages that need rendered content (archive pages showing excerpts, search indexes) must either:
-1. Move their logic into a template (which has access to `renderInnerPage()`)
-2. Bring their own markdown renderer as a dependency
+### 2. Architecture explanation: when rendered content is available
 
----
+The build pipeline has a clear ordering that determines when rendered content can be accessed:
 
-## Expected behavior
+| Build stage | `renderInnerPage()` available? | Why |
+|---|---|---|
+| `global.data.js` | No | Runs before rendering stage |
+| Page functions (`page.js`) | No | Pages receive vars, not other pages' rendered output |
+| Templates (`.template.js`) | Yes | Run after page initialization and global data |
+| Layouts | No | Receive already-rendered `children` for their own page |
 
-1. `renderInnerPage()` should be **documented** as the official API for accessing rendered content in templates.
-2. There should be a **documented path** for accessing rendered content in `global.data.js`, or clear documentation explaining why it is not possible and what the recommended architecture is.
+### 3. Performance guidance
+
+For feeds and other outputs that render multiple pages:
+- Use `Promise.all()` for parallel rendering
+- Cache results in a `Map` when the same page appears in multiple outputs
+- Use `new Map(pages.map(p => [p.pageInfo.path, p]))` for O(1) page lookup
 
 ---
 
 ## Workaround
 
-The current workaround has two parts:
-
-**For templates (feeds, standalone generated pages):** Use `renderInnerPage()` directly, as shown in `src/feeds.template.js` above. This works today but requires reading source code to discover.
-
-**For page functions (archives, indexes):** Accept raw markdown from `vars.content` and either render it client-side or accept unrendered content. This codebase's `src/archive/page.js` and `src/page.js` use the raw `content` field from `global.data.js`:
+This codebase's `src/feeds.template.js` demonstrates the complete pattern — page lookup index, parallel rendering with caching, and cache reuse across multiple feed outputs:
 
 ```js
-// src/page.js -- uses raw content from global.data.js
-export default function homePage ({ vars: pageVars }) {
-  const recentPosts = pageVars.recentPosts || [];
-  const postListItems = recentPosts.map(post =>
-    renderPost({
-      post,
-      content: post.content || '',  // This is raw markdown for .md pages
-      // ...
-    })
-  ).join('\n    ');
-  // ...
+// Build page index for O(1) lookup
+const pagesByPath = new Map(pages.map(p => [p.pageInfo.path, p]));
+
+// Pre-render all unique feed posts in parallel, with cache
+const renderCache = new Map();
+await Promise.all(allFeedPosts.map(async (post) => {
+  const page = pagesByPath.get(post.path);
+  const html = page ? await page.renderInnerPage({ pages }) : '';
+  renderCache.set(post.path, html);
+}));
+
+// Use cached rendered HTML in feed entries
+function buildFeed ({ posts }) {
+  return posts.map(post => {
+    const html = renderCache.get(post.path) || '';
+    return renderRssEntry({ content: html, post, siteUrl });
+  });
 }
 ```
+
+This pattern works well but was assembled through source-code reading and experimentation.
 
 ---
 
 ## Proposed solution
 
-### Part 1: Document `renderInnerPage()` (immediate, no code changes)
+### Part 1: Add a "Rendered Content" reference to the docs
 
-Add a "Rendered Content" section to the docs:
+Add a brief section near the Templates documentation:
 
 ```markdown
-## Accessing rendered page content
-
-### In templates
+### Accessing rendered page content
 
 Templates can render any page's inner content using `renderInnerPage()`:
 
-\`\`\`js
-export default async function * feedTemplate ({ pages, vars }) {
-  const pagesByPath = new Map(pages.map(p => [p.pageInfo.path, p]));
+    const html = await page.renderInnerPage({ pages });
 
-  for (const post of recentPosts) {
-    const page = pagesByPath.get(post.path);
-    const html = page ? await page.renderInnerPage({ pages }) : '';
-    yield { outputName: `feed/${post.path}.html`, content: html };
-  }
-}
-\`\`\`
-
-**Key points:**
 - `renderInnerPage({ pages })` returns the page content rendered by its builder
   (e.g., markdown-to-HTML), **without** the layout wrapper.
 - `renderFullPage({ pages })` returns the complete page with layout applied.
-- Both methods are async and return Promises.
-- You must pass the full `pages` array as a parameter.
+- Both methods are async and require passing the full `pages` array.
 - For performance, render in parallel with `Promise.all()` and cache results
-  when multiple feeds or outputs need the same rendered content.
+  when multiple outputs need the same rendered content.
 
-### In global.data.js
-
-`global.data.js` runs before the rendering stage. Rendered HTML is **not available**
-in this context. Use `vars.content` for raw source content, or move rendering
-logic to a template.
-
-### Architecture recommendation
-
-If you need rendered content in multiple outputs (feeds + archive + search):
-1. Use a **template** (async generator) to generate all outputs that need rendered HTML.
-2. Use `global.data.js` for metadata aggregation (titles, dates, paths, tags)
-   that doesn't require rendered content.
+**Note:** `renderInnerPage()` is available in templates only. `global.data.js`
+runs before the rendering stage and cannot access rendered content. Use
+`vars.content` for raw source content, or move rendering logic to a template.
 ```
 
-### Part 2: Consider making `renderInnerPage()` available in `global.data.js` (future enhancement)
+### Part 2: Consider making `renderInnerPage()` available in `global.data.js` (future)
 
 Three possible approaches, in order of feasibility:
 
 | Approach | Description | Trade-offs |
 |----------|-------------|------------|
-| **Lazy `renderedContent` property** | Add a `get renderedContent()` getter to `PageData` that lazily renders and caches the result | Simplest API; risk of circular dependencies if global data affects rendering |
-| **Two-pass `global.data.js`** | Run `global.data.js` twice: once before rendering (metadata), once after (with rendered content) | Complex; ordering semantics unclear |
-| **Document the architecture** | Officially document that rendered content belongs in templates, not global data | No code changes; may disappoint users wanting rendered content in page functions |
+| **Lazy `renderedContent` getter** | Lazily renders and caches on first access | Simplest API; risk of circular dependencies |
+| **Two-pass global.data** | Run once for metadata, once after rendering | Complex ordering semantics |
+| **Document the architecture** | Officially document that rendered content belongs in templates | No code changes; may not satisfy all use cases |
 
-The third option (documentation) is the pragmatic immediate fix. The first option (lazy getter) would be the best long-term DX improvement if the pipeline ordering can be resolved.
+The documentation approach (Part 1) is the pragmatic immediate fix.
 
 ---
 
 ## Real-world impact
 
-This codebase demonstrates the split perfectly:
+This codebase demonstrates the split:
 
 | File | Needs rendered HTML? | Current approach |
 |------|---------------------|------------------|
-| `src/feeds.template.js` | Yes (Atom feed entries) | Uses `renderInnerPage()` -- works |
+| `src/feeds.template.js` | Yes (Atom feed entries) | Uses `renderInnerPage()` — works |
 | `src/page.js` (homepage) | Ideally yes (post previews) | Uses raw `content` from global.data |
 | `src/archive/page.js` | Ideally yes (archive entries) | Uses raw `content` from global.data |
 | `src/links/page.js` | Ideally yes (link descriptions) | Uses raw `content` from global.data |
 | `src/social/page.js` | Ideally yes (social posts) | Uses raw `content` from global.data |
 | `src/sitemap.xml.template.js` | No (URLs only) | N/A |
 
-Five out of six consumer files would benefit from rendered HTML access. Currently only the feeds template has it, because it is the only template that discovered the undocumented `renderInnerPage()` API.
+The feeds template is the only consumer with access to rendered HTML because it is the only template that uses `renderInnerPage()`. The other consumers receive raw markdown from `global.data.js`, which is a design trade-off rather than a bug.
 
 ---
 
 ## Related issues
 
 - **#01** -- Exporting `PageData` types would make `renderInnerPage()` discoverable via autocompletion.
-- **#02** -- The `global.data.js` documentation should cross-reference this issue's caveat about `vars.content` being raw source.
-- **#05** -- Template return type documentation should include examples using `renderInnerPage()` since that is a primary template use case.
+- **#02** -- The `global.data.js` caveats documentation should cross-reference this issue's explanation of why rendered content is unavailable there.
+- **#09** -- Template `vars` not including `global.data.js` output means templates must re-derive post data even when using `renderInnerPage()`, compounding the complexity.

--- a/domstack-issues/05-document-template-return-types.md
+++ b/domstack-issues/05-document-template-return-types.md
@@ -1,4 +1,4 @@
-# Document all template return types (string, object, array, async iterator)
+# Add "when to use which" guidance for template return types
 
 `Labels: documentation, dx`
 
@@ -6,9 +6,9 @@
 
 ## Problem
 
-The DomStack template builder supports **four distinct return types**, but documentation primarily shows (or only shows) the async iterator pattern. Users who want to generate a simple file like `robots.txt` or `manifest.json` end up using an async generator because they do not know that simpler return formats work.
+The DomStack README documents all four template return types (string, object, array, async iterator) with full TypeScript examples and type annotations. However, it presents them as equal options without guidance on **when to use which**. Users who encounter the array or async iterator examples first may default to more complex patterns even for trivial single-file templates.
 
-The type definitions clearly enumerate all four return types:
+The type definitions enumerate the four return types:
 
 ```typescript
 // From @domstack/static/lib/build-pages/page-builders/template-builder.d.ts
@@ -29,271 +29,26 @@ export type TemplateReport = {
 };
 ```
 
-The `TemplateReport.type` field confirms the builder detects and handles all four:
-1. `"content"` -- plain string return
-2. `"object"` -- single `TemplateOutputOverride` return
-3. `"array"` -- array of `TemplateOutputOverride` returns
-4. `"async-iterator"` -- async generator yielding `TemplateOutputOverride` values
-
-But without documentation, users default to the most complex pattern even when a simpler one would suffice.
+The README documents all four with examples, but does not provide a comparison table or decision guide.
 
 ---
 
-## Current behavior
+## What the README already covers
 
-A user wanting to generate `robots.txt` might write this because docs only show the generator pattern:
+The README's "Templates" section documents each return type with a complete example:
 
-```js
-// Over-engineered -- user doesn't know simpler options exist
-export default async function* robotsTemplate ({ vars }) {
-  yield {
-    outputName: 'robots.txt',
-    content: `User-Agent: *\nDisallow: /private/`,
-  };
-}
-```
+1. **Simple string template** -- returns a string, output name derived from template filename
+2. **Object template** -- returns `{ content, outputName }` for custom output paths
+3. **Object array template** -- returns an array of `{ content, outputName }` objects
+4. **AsyncIterator template** -- async generator yielding `{ content, outputName }` values
 
-Or they might use the array pattern because they saw it in an example, even for a single output:
-
-```js
-// Unnecessary array wrapper for single output
-export default function robotsTemplate ({ vars }) {
-  return [{
-    outputName: 'robots.txt',
-    content: `User-Agent: *\nDisallow: /private/`,
-  }];
-}
-```
-
-When the simplest correct version is:
-
-```js
-// Simplest -- but user doesn't know this works
-export default function robotsTemplate ({ vars }) {
-  return `User-Agent: *\nDisallow: /private/`;
-}
-```
+Each includes TypeScript type annotations (`TemplateFunction<T>`, `TemplateAsyncIterator<T>`).
 
 ---
 
-## Expected behavior
+## What's missing
 
-Documentation should present all four return types with clear guidance on when to use each, ordered from simplest to most flexible.
-
----
-
-## Workaround
-
-Users read the TypeScript definitions or study example codebases. This codebase contains templates using three of the four return types, providing a natural reference -- but only if users know to look:
-
-<details>
-<summary>All template files in this codebase and their return types</summary>
-
-**Array return** -- `src/robots.txt.template.js`:
-```js
-export default function robotsTemplate (_options) {
-  return [{
-    outputName: 'robots.txt',
-    content: `User-agent: *
-Disallow: /webpage-kodfabrik-se/
-Disallow: /webpage-svpt-nu/
-`,
-  }];
-}
-```
-
-**Array return** -- `src/manifest.json.template.js`:
-```js
-export default function manifestTemplate (_options) {
-  return [{
-    outputName: 'manifest.json',
-    content: JSON.stringify({
-      short_name: 'Pelle Wessman',
-      name: "Pelle Wessman's Blog",
-      icons: [{ src: 'images/launcher-icon.png', sizes: '192x192', type: 'image/png' }],
-      // ...
-    }, undefined, 2) + '\n',
-  }];
-}
-```
-
-**Array return** -- `src/sitemap.xml.template.js`:
-```js
-export default function sitemapTemplate ({ pages, vars }) {
-  const siteUrl = vars.siteUrl;
-  const urls = pages.map(p => {
-    const url = p.pageInfo?.path ? '/' + p.pageInfo.path + '/' : '/';
-    return `  <url><loc>${escapeXml(siteUrl + url)}</loc></url>`;
-  }).join('\n');
-
-  return [{
-    outputName: 'sitemap.xml',
-    content: `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls}
-</urlset>
-`,
-  }];
-}
-```
-
-**Array return** -- `src/redirects.template.js` (generates multiple redirect pages):
-```js
-export default function redirectsTemplate () {
-  return redirects.map(({ from, to }) => ({
-    outputName: `${from}/index.html`,
-    content: `<!DOCTYPE html>
-<html>
-<head><meta http-equiv="refresh" content="0;url=${escapeXml(to)}" /></head>
-<body><p>Redirecting to <a href="${escapeXml(to)}">${escapeXml(to)}</a></p></body>
-</html>`,
-  }));
-}
-```
-
-**Async iterator return** -- `src/feeds.template.js`:
-```js
-export default async function * feedsTemplate ({ pages, vars }) {
-  // ...pre-render posts with renderInnerPage()...
-
-  yield { outputName: 'all.xml', content: await buildFeed({ /* ... */ }) };
-  yield { outputName: 'english.xml', content: await buildFeed({ /* ... */ }) };
-  yield { outputName: 'links/all.xml', content: await buildFeed({ /* ... */ }) };
-}
-```
-
-Note: `robots.txt.template.js`, `manifest.json.template.js`, and `sitemap.xml.template.js` all use the array return for a single output. They could use the simpler string or object return if they knew those existed.
-
-</details>
-
----
-
-## Proposed solution
-
-Add a "Template Return Types" section to the documentation with all four formats, ordered from simplest to most flexible.
-
-### Proposed documentation content
-
-```markdown
-## Template Return Types
-
-Templates (`.template.js` / `.template.ts` files) support four return formats.
-Use the simplest one that fits your needs.
-
-### 1. String -- Single output, default filename
-
-**Best for:** Simple generated files where the template filename determines the output.
-
-The output filename is derived from the template filename by removing the
-`.template.js` suffix: `robots.txt.template.js` produces `robots.txt`.
-
-\`\`\`js
-// src/robots.txt.template.js
-export default function ({ vars }) {
-  return `User-Agent: *
-Disallow: /private/`;
-}
-\`\`\`
-
-**Output:** `robots.txt`
-
-### 2. Object -- Single output with custom filename
-
-**Best for:** Single files where you need to control the output path or filename.
-
-Return an object with `outputName` (the output path relative to the site root)
-and `content` (the file content as a string).
-
-\`\`\`js
-// src/config.template.js
-export default function ({ vars }) {
-  return {
-    outputName: 'config.json',
-    content: JSON.stringify({ siteUrl: vars.siteUrl }, null, 2),
-  };
-}
-\`\`\`
-
-**Output:** `config.json`
-
-### 3. Array -- Multiple outputs from one template
-
-**Best for:** Generating several related files from a single data source.
-
-Return an array of `{ outputName, content }` objects. Each element produces
-one output file.
-
-\`\`\`js
-// src/feeds.template.js
-export default function ({ vars, pages }) {
-  return [
-    { outputName: 'feed.xml', content: buildAtomFeed(vars, pages) },
-    { outputName: 'feed.json', content: buildJsonFeed(vars, pages) },
-    { outputName: 'sitemap.xml', content: buildSitemap(vars, pages) },
-  ];
-}
-\`\`\`
-
-**Output:** `feed.xml`, `feed.json`, `sitemap.xml`
-
-This is also the natural pattern for generating redirect pages or other
-file-per-item outputs:
-
-\`\`\`js
-// src/redirects.template.js
-export default function () {
-  return redirects.map(({ from, to }) => ({
-    outputName: `${from}/index.html`,
-    content: `<meta http-equiv="refresh" content="0;url=${to}" />`,
-  }));
-}
-\`\`\`
-
-### 4. Async Iterator -- Streaming multiple outputs
-
-**Best for:** Outputs that require async operations (rendering other pages,
-network requests) or large numbers of generated files.
-
-Use an async generator function (`async function*`) and `yield` each output.
-
-\`\`\`js
-// src/feeds.template.js
-export default async function* ({ pages, vars }) {
-  const pagesByPath = new Map(pages.map(p => [p.pageInfo.path, p]));
-
-  for (const post of recentPosts) {
-    const page = pagesByPath.get(post.path);
-    const html = page ? await page.renderInnerPage({ pages }) : '';
-
-    yield {
-      outputName: `rendered/${post.path}/index.html`,
-      content: html,
-    };
-  }
-}
-\`\`\`
-
-**Output:** One file per post, generated incrementally.
-
-This pattern is required when using `renderInnerPage()` because it is async.
-It is also useful when generating hundreds of files, as it avoids holding all
-output strings in memory simultaneously.
-
-### Template function parameters
-
-All four formats receive the same parameters:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `vars` | `T` | Merged global variables (`global.vars.js` only -- not `global.data.js` output) |
-| `template` | `TemplateInfo` | Metadata about the template file (path, outputName) |
-| `pages` | `PageData<T>[]` | Array of all resolved page objects |
-
-**Important:** Template `vars` come from `global.vars.js` only. They do not
-include `global.data.js` output. To access data computed by `global.data.js`,
-iterate `pages` and read their `vars` (which do include global data).
-
-### When to use which
+A **decision guide** or comparison table that helps users choose the simplest pattern for their needs. The README presents all four types sequentially without explicitly recommending that users prefer the simplest sufficient pattern. Adding something like a "When to use which" table would complete the documentation:
 
 | Return type | Sync? | Custom filename? | Multiple outputs? | Async operations? |
 |-------------|-------|-------------------|--------------------|--------------------|
@@ -301,23 +56,12 @@ iterate `pages` and read their `vars` (which do include global data).
 | Object | Yes | Yes | No | No |
 | Array | Yes | Yes | Yes | No |
 | Async Iterator | No | Yes | Yes | Yes |
-```
-
----
-
-## Alternatives considered
-
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Docs section (proposed)** | Complete reference, guides users to simplest option | Requires maintenance as API evolves |
-| **Starter template scaffolds** | Hands-on, immediate | Only helps new projects; does not help existing users |
-| **Console hint on first template build** | Discoverable at point of use | Adds noise to build output |
 
 ---
 
 ## Real-world impact
 
-This codebase has **5 template files**. All of them use either the array or async iterator pattern. At least three (`robots.txt.template.js`, `manifest.json.template.js`, `sitemap.xml.template.js`) could be simplified:
+This codebase demonstrates the problem: **three templates** use array returns for single outputs when simpler patterns would suffice. This happened because the templates were written before the simpler patterns were well-known:
 
 | Template | Current return type | Simplest sufficient type | Lines saved |
 |----------|--------------------|-----------------------|-------------|
@@ -327,7 +71,13 @@ This codebase has **5 template files**. All of them use either the array or asyn
 | `src/redirects.template.js` | Array (N elements) | Array (correct) | 0 |
 | `src/feeds.template.js` | Async iterator | Async iterator (correct) | 0 |
 
-Beyond this codebase, every DomStack user writing templates benefits from knowing the full range of return types. The string return type in particular is a significant simplification for common generated files.
+These templates have been simplified as part of this review to use the appropriate return types.
+
+---
+
+## Proposed solution
+
+Add a brief "When to use which" comparison table to the existing Templates documentation section, after the four return type examples. This is a small addition -- no new section is needed, just a summary that ties the existing examples together.
 
 ---
 
@@ -336,3 +86,4 @@ Beyond this codebase, every DomStack user writing templates benefits from knowin
 - **#01** -- Exporting `TemplateOutputOverride`, `TemplateFunctionParams`, and `TemplateInfo` types would make the documented API importable for type checking.
 - **#02** -- The distinction between `vars` in templates (global.vars only) vs `vars` in page functions (includes global.data) should be cross-referenced.
 - **#03** -- The async iterator pattern is the primary way to use `renderInnerPage()`, which is documented in issue #03.
+- **#09** -- Template `vars` not including `global.data.js` output is the reason templates must re-derive data from the `pages` array.

--- a/domstack-issues/06-layout-composition-docs.md
+++ b/domstack-issues/06-layout-composition-docs.md
@@ -1,4 +1,4 @@
-# Document layout composition and inheritance pattern
+# Strengthen layout composition documentation with pitfall warnings
 
 `Labels: documentation, dx`
 
@@ -6,93 +6,105 @@
 
 ## Problem
 
-DomStack supports multiple layouts (e.g., `root.layout.js`, `article.layout.js`, `blog-index.layout.js`), and layouts are plain functions that can compose by importing and calling each other. This is a powerful, flexible pattern -- but it is entirely undocumented.
+The DomStack README has a "Nested layouts" section that documents the core layout composition pattern: importing a base layout, wrapping content, and delegating via rest spread. It includes a full example of `blog.layout.ts` extending `root.layout.ts`.
 
-In practice, most sites have a **base layout** (the full HTML document shell) and one or more **specialized layouts** (article, archive, landing page) that wrap their content and delegate to the base. Users must figure this out by reading example codebases or through trial and error. Key questions go unanswered:
+However, the documentation does not cover several practical pitfalls that users encounter when composing layouts:
 
-1. Is manually importing and calling another layout the **intended** pattern, or a hack?
-2. Which parameters (`scripts`, `styles`, `page`, `pages`, `workers`) must be forwarded to the base layout, and what breaks if they are not?
-3. Can layouts nest more than two levels deep?
-4. Can the extending layout modify `vars` before forwarding?
-5. What is the relationship between layout CSS/JS files and composed layouts?
+1. **What breaks when `scripts`/`styles` are not forwarded** — the README shows them being forwarded via rest spread, but does not explain that forgetting to forward them causes silent failure (pages render without CSS/JS bundles, no error).
+2. **Modifying `vars` before forwarding** — the README example uses rest spread to forward everything, but does not show the pattern of adding or overriding vars (e.g., adding `author: true`, `hfeed: true`) before delegating.
+3. **Forwarding `page`, `pages`, and `workers`** — the README's layout function signature documents these params, but the nested layout example does not show forwarding them. Layouts that need page introspection (e.g., breadcrumbs, related posts) must know to forward these explicitly.
+4. **Layout-specific CSS/JS with nested layouts** — the README has a dedicated "Nested layout TS/JS bundles and styles" section explaining that composed layouts must manually `@import` / `import` parent layout assets. This is documented, but easy to miss.
 
 ---
 
-## Current behavior
+## What the README already covers
 
-Layout composition works today -- this codebase uses it -- but the pattern must be reverse-engineered from examples. Here is the actual composition in this site:
+The README's "Nested layouts" section documents:
 
-### Base layout: `src/root.layout.js`
+- **Core pattern**: Importing and calling another layout function (with a full `blog.layout.ts` example)
+- **Rest spread forwarding**: `const { children: innerChildren, ...rest } = layoutVars` and `return defaultRootLayout(rootArgs)`
+- **Layout function signature**: All params (`vars`, `scripts`, `styles`, `children`, `pages`, `page`, `workers`) are documented in the default root layout section
+- **Layout CSS/JS inheritance**: A dedicated "Nested layout TS/JS bundles and styles" sub-section explains that `@import "./root.layout.css"` and `import './root.layout.client.ts'` are needed for composed layouts
+- **LayoutFunction type**: `LayoutFunction<T, U, V>` with three type parameters is documented
+
+---
+
+## What's missing
+
+### 1. Warning about the silent failure mode
+
+If `scripts` and `styles` are not forwarded to the base layout, the page renders without CSS or JS bundles. There is no error message — the page simply appears unstyled and without client-side functionality. This is the most common layout composition mistake and should be explicitly warned about.
 
 ```js
-import { html, rawHtml, renderToStringSync } from 'async-htm-to-string';
+// WRONG -- scripts and styles are silently lost
+return rootLayout({ children: wrappedContent, vars });
 
-export default function rootLayout ({ children, scripts = [], styles = [], vars }) {
-  const blogName = String(vars.blogName || '');
-  const siteUrl = String(vars.siteUrl || '');
-  const title = vars.frontpage
-    ? blogName
-    : (vars.title ? `${vars.title} – ${blogName}` : blogName);
+// CORRECT -- scripts and styles are forwarded
+return rootLayout({ children: wrappedContent, vars, scripts, styles });
+```
 
-  const headContent = renderToStringSync(html`
-    <meta charset="utf-8" />
-    <title>${title}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    ${styles.map(href => html`<link rel="stylesheet" href=${href} />`)}
-    <!-- ...feeds, canonical, meta tags... -->
-  `);
+### 2. Pattern for modifying vars before forwarding
 
-  const bodyContent = renderToStringSync(html`
-    <div class="page">
-      <header><h1><a href="/">${blogName}</a></h1></header>
-      ${rawHtml(children)}
-    </div>
-    ${scripts.map(src => html`<script type="module" src=${src}></script>`)}
-  `);
+The README's example uses rest spread, which forwards vars unchanged. A common need is to add layout-specific flags:
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>${headContent}</head>
-<body>${bodyContent}</body>
-</html>`;
+```js
+const layoutVars = {
+  ...vars,
+  author: true,
+  hfeed: true,
+  webmentionable: true,
+};
+return rootLayout({ children: wrappedContent, vars: layoutVars, scripts, styles });
+```
+
+This pattern is used in this codebase's `src/article.layout.js` and is a natural extension of the documented pattern, but not shown in the README.
+
+### 3. Explicit param forwarding list
+
+When layouts use `page`, `pages`, or `workers`, these must also be forwarded. A checklist of "params to forward" would help:
+
+```js
+export default function articleLayout ({ children, vars, scripts, styles, page, pages, workers }) {
+  return rootLayout({
+    children: wrappedContent,
+    vars: layoutVars,
+    scripts,    // Hash-busted CSS/JS paths — MUST forward
+    styles,     // Hash-busted CSS/JS paths — MUST forward
+    page,       // Forward if base layout uses page introspection
+    pages,      // Forward if base layout uses page listing
+    workers,    // Forward if base layout uses web workers
+  });
 }
 ```
 
-### Extending layout: `src/article.layout.js`
+---
+
+## Proposed solution
+
+Add a "Layout composition pitfalls" subsection to the existing "Nested layouts" documentation:
+
+1. A warning box about the silent failure when `scripts`/`styles` are not forwarded
+2. An example showing `vars` modification before forwarding
+3. A quick-reference list of params that should be forwarded and why
+
+This is a small addition to existing documentation, not a new section.
+
+---
+
+## Real-world impact
+
+This codebase demonstrates the correct pattern in `src/article.layout.js`:
 
 ```js
-import { html, renderToStringSync } from 'async-htm-to-string';
-import { renderPostContent } from './lib/render-post-content.js';
-import rootLayout from './root.layout.js';
-
 export default function articleLayout ({ children, scripts = [], styles = [], vars }) {
-  const articleHtml = renderPostContent({
-    authorName: vars.authorName,
-    content: children,
-    post: { ...vars, pageUrl: vars.pageUrl || '' },
-    siteUrl: vars.siteUrl,
-    standalone: true,
-    // ...
-  });
+  // Wrap content
+  const articleHtml = renderPostContent({ /* ... */ });
+  const webmentionForm = renderToStringSync(html`...`);
 
-  const webmentionForm = renderToStringSync(html`
-    <div>
-      Have you written a response to this? Let me know the URL:
-      <form action=${`${vars.webmentionEndpoint}/api/webmention`} method="post">
-        <!-- ...form fields... -->
-      </form>
-    </div>
-  `);
+  // Modify vars before forwarding
+  const layoutVars = { ...vars, author: true, hfeed: true, webmentionable: true };
 
-  // Modify vars before forwarding to base layout
-  const layoutVars = {
-    ...vars,
-    author: true,
-    hfeed: true,
-    webmentionable: true,
-  };
-
-  // Delegate to root layout, forwarding scripts and styles
+  // Forward scripts and styles correctly
   return rootLayout({
     children: articleHtml + '\n' + webmentionForm,
     scripts,
@@ -102,269 +114,7 @@ export default function articleLayout ({ children, scripts = [], styles = [], va
 }
 ```
 
-### How pages select a layout
-
-Pages declare their layout in their exported `vars`:
-
-```js
-// src/page.js (homepage) -- uses root layout
-export const vars = {
-  layout: 'root',
-  title: 'Pelle Wessman',
-  frontpage: true,
-};
-
-// A markdown post -- uses article layout (via frontmatter or page.vars.js)
-// vars: { layout: 'article', title: 'My Post', date: '2024-01-15' }
-```
-
-DomStack matches `layout: 'article'` to `article.layout.js` by filename convention. The article layout then internally composes with `root.layout.js`.
-
----
-
-## Expected behavior
-
-A documentation section should explain:
-1. That layout composition via imports is the **intended and recommended** pattern
-2. The complete layout function signature (all parameters)
-3. Which parameters must be forwarded and why
-4. How to modify vars before forwarding
-5. Multi-level nesting
-6. How layout-specific CSS and JS files interact with composition
-
----
-
-## Workaround
-
-Users study existing codebases or experiment. The most common failure mode is **forgetting to forward `scripts` and `styles`** to the base layout, which causes DomStack's hash-busted CSS and JS bundles to silently disappear from the rendered page. This is a subtle bug because the page renders without styles/scripts but produces no error.
-
----
-
-## Proposed solution
-
-Add a "Layout Composition" section to the DomStack documentation.
-
-### Proposed documentation content
-
-```markdown
-## Layout Composition
-
-Layouts are plain JavaScript functions, so they compose naturally via imports.
-The recommended pattern is a **base layout** for the HTML document shell and
-**specialized layouts** for different content types.
-
-### Layout function signature
-
-Every layout function receives a single object with these properties:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `children` | `string` (or custom type) | The rendered inner page content |
-| `vars` | `Record<string, any>` | Merged page variables (global.vars + global.data + page.vars + builder vars) |
-| `scripts` | `string[]` | Script paths for this page (global + page-specific + layout-specific) |
-| `styles` | `string[]` | Stylesheet paths for this page (global + page-specific + layout-specific) |
-| `page` | `PageInfo` | Static metadata about the current page |
-| `pages` | `PageData[]` | Array of all resolved page objects |
-| `workers` | `Record<string, string>` | Web worker file paths for this page |
-
-### Base layout
-
-The base layout renders the full HTML document. It is responsible for
-injecting stylesheets and scripts into the appropriate locations.
-
-\`\`\`js
-// src/root.layout.js
-export default function rootLayout ({ children, vars, scripts = [], styles = [] }) {
-  return \`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>\${vars.title || 'My Site'}</title>
-  \${styles.map(s => \`<link rel="stylesheet" href="\${s}">\`).join('\\n  ')}
-</head>
-<body>
-  <header><h1><a href="/">\${vars.siteName}</a></h1></header>
-  \${children}
-  \${scripts.map(s => \`<script type="module" src="\${s}"></script>\`).join('\\n  ')}
-</body>
-</html>\`;
-}
-\`\`\`
-
-### Extending a layout
-
-An extending layout imports the base, wraps the content, and delegates:
-
-\`\`\`js
-// src/article.layout.js
-import rootLayout from './root.layout.js';
-
-export default function articleLayout ({ children, vars, scripts, styles }) {
-  const articleHtml = \`<article>
-    <h1>\${vars.title}</h1>
-    <time>\${vars.date}</time>
-    \${children}
-  </article>\`;
-
-  // Modify vars for the base layout
-  const baseVars = { ...vars, showAuthorCard: true };
-
-  // IMPORTANT: forward scripts and styles to the base layout
-  return rootLayout({
-    children: articleHtml,
-    vars: baseVars,
-    scripts,
-    styles,
-  });
-}
-\`\`\`
-
-### Critical: forwarding scripts and styles
-
-**Always forward `scripts` and `styles` to the base layout.** These arrays
-contain the hash-busted paths to your CSS and JS bundles (e.g.,
-\`/global-A1B2C3D4.css\`). If you do not forward them, the base layout has
-no way to inject \`<link>\` and \`<script>\` tags, and your page will render
-without styles or client-side JavaScript.
-
-\`\`\`js
-// WRONG -- scripts and styles are lost
-return rootLayout({ children: wrappedContent, vars });
-
-// CORRECT -- scripts and styles are forwarded
-return rootLayout({ children: wrappedContent, vars, scripts, styles });
-\`\`\`
-
-This is the most common layout composition mistake because it produces no error --
-the page simply renders without its assets.
-
-### Multi-level nesting
-
-Layouts can nest any number of levels. Each level wraps the content and
-delegates upward:
-
-\`\`\`js
-// src/blog-index.layout.js
-import rootLayout from './root.layout.js';
-
-export default function blogIndexLayout ({ children, vars, scripts, styles }) {
-  const navHtml = \`<nav>...</nav>\`;
-  return rootLayout({
-    children: navHtml + children,
-    vars: { ...vars, hfeed: true },
-    scripts,
-    styles,
-  });
-}
-
-// src/blog-post.layout.js
-import blogIndexLayout from './blog-index.layout.js';
-
-export default function blogPostLayout ({ children, vars, scripts, styles }) {
-  const postHtml = \`<article>\${children}</article>\`;
-  return blogIndexLayout({
-    children: postHtml,
-    vars: { ...vars, showAuthorCard: true },
-    scripts,
-    styles,
-  });
-}
-\`\`\`
-
-Chain: page content -> blogPostLayout -> blogIndexLayout -> rootLayout
-
-### Forwarding additional params
-
-If your layouts use \`page\`, \`pages\`, or \`workers\`, forward those as well:
-
-\`\`\`js
-export default function articleLayout ({ children, vars, scripts, styles, page, pages, workers }) {
-  // Use page.path for breadcrumbs, pages for related posts, etc.
-  const breadcrumb = \`<nav>Home > \${page.path}</nav>\`;
-
-  return rootLayout({
-    children: breadcrumb + children,
-    vars,
-    scripts,
-    styles,
-    page,
-    pages,
-    workers,
-  });
-}
-\`\`\`
-
-### Modifying vars
-
-You can add, override, or remove vars before forwarding. This is the
-recommended way to pass layout-specific signals to the base layout:
-
-\`\`\`js
-// The article layout adds 'author' and 'webmentionable' flags
-// that the root layout uses to render author cards and webmention links
-const layoutVars = {
-  ...vars,
-  author: true,
-  hfeed: true,
-  webmentionable: true,
-};
-return rootLayout({ children: wrappedContent, vars: layoutVars, scripts, styles });
-\`\`\`
-
-### Layout-specific CSS and JS
-
-Each layout can have an associated CSS and/or JS file:
-
-- \`article.layout.css\` -- Styles specific to the article layout
-- \`article.layout.client.js\` -- Client JS specific to the article layout
-
-These are automatically bundled by esbuild and their hash-busted paths are
-included in the \`styles\` and \`scripts\` arrays passed to the layout function.
-When composing layouts, forwarding \`styles\` and \`scripts\` ensures that
-layout-specific assets from child layouts reach the base layout's \`<head>\`
-and \`<body>\` injection points.
-
-### Tips
-
-- Layouts are just functions -- use any JavaScript pattern: conditionals,
-  shared helper functions, template literals, JSX, or tagged template libraries.
-- Since layouts receive all pages via \`pages\`, you can build navigation,
-  related posts, or other cross-page features directly in a layout.
-- The \`page\` param provides \`page.type\` (\`"js" | "md" | "html"\`), which
-  lets a layout render differently based on the page builder type.
-```
-
----
-
-## Alternatives considered
-
-| Approach | Pros | Cons |
-|----------|------|------|
-| **Docs section (proposed)** | Comprehensive, covers pitfalls, includes real examples | Requires maintenance |
-| **Built-in layout extends mechanism** | Would formalize the pattern (e.g., `export const extends = 'root'`) | Adds API surface; plain function composition is more flexible and idiomatic |
-| **Starter template with composition example** | Hands-on learning | Only helps new projects; does not help existing users |
-
-Plain function composition is the right design -- it is maximally flexible and requires no framework-specific concepts. The gap is purely documentation.
-
----
-
-## Real-world impact
-
-This codebase demonstrates the pattern with two layouts:
-
-| Layout | Role | Composes with |
-|--------|------|---------------|
-| `src/root.layout.js` | Base HTML document (79 lines) | N/A (top-level) |
-| `src/article.layout.js` | Article/post wrapper with webmention form (60 lines) | Imports and calls `root.layout.js` |
-
-Pages using each layout:
-
-| Layout | Used by |
-|--------|---------|
-| `root` | `src/page.js`, `src/archive/page.js`, `src/links/page.js`, `src/social/page.js` |
-| `article` | All markdown blog posts (80+ posts across `src/2008/` through `src/2019/`) |
-
-The article layout correctly forwards `scripts` and `styles` and modifies `vars` to add `author: true`, `hfeed: true`, and `webmentionable: true` -- all patterns that should be documented so every DomStack user does the same.
+This pattern works correctly, but was discovered through experimentation rather than documentation. Documenting the pitfalls would help other DomStack users avoid the silent failure mode.
 
 ---
 
@@ -372,4 +122,3 @@ The article layout correctly forwards `scripts` and `styles` and modifies `vars`
 
 - **#01** -- Exporting `LayoutFunctionParams` would let users type their layout functions precisely, especially the `page`, `pages`, and `workers` params that are easy to forget.
 - **#02** -- The variable merge order documented in issue #02 explains why `vars` in a layout contains `global.data.js` output (which affects what data layouts can access).
-- **#05** -- Template return types are a related customization point; templates and layouts are the two primary "output-shaping" mechanisms in DomStack.

--- a/src/manifest.json.template.js
+++ b/src/manifest.json.template.js
@@ -1,9 +1,9 @@
 /**
  * @param {{ vars: Record<string, unknown> }} _options
- * @returns {Array<{outputName: string, content: string}>}
+ * @returns {{outputName: string, content: string}}
  */
 export default function manifestTemplate (_options) {
-  return [{
+  return {
     outputName: 'manifest.json',
     content: JSON.stringify({
       short_name: 'Pelle Wessman',
@@ -21,5 +21,5 @@ export default function manifestTemplate (_options) {
       scope: '/',
       display: 'standalone',
     }, undefined, 2) + '\n',
-  }];
+  };
 }

--- a/src/robots.txt.template.js
+++ b/src/robots.txt.template.js
@@ -1,13 +1,10 @@
 /**
  * @param {{ vars: Record<string, unknown> }} _options
- * @returns {Array<{outputName: string, content: string}>}
+ * @returns {string}
  */
 export default function robotsTemplate (_options) {
-  return [{
-    outputName: 'robots.txt',
-    content: `User-agent: *
+  return `User-agent: *
 Disallow: /webpage-kodfabrik-se/
 Disallow: /webpage-svpt-nu/
-`,
-  }];
+`;
 }

--- a/src/sitemap.xml.template.js
+++ b/src/sitemap.xml.template.js
@@ -2,7 +2,7 @@ import { escapeXml } from './lib/escape.js';
 
 /**
  * @param {{ vars: Record<string, unknown>, pages: Array<{ pageInfo: { path: string, outputRelname: string } }> }} options
- * @returns {Array<{outputName: string, content: string}>}
+ * @returns {{outputName: string, content: string}}
  */
 export default function sitemapTemplate ({ pages, vars }) {
   const siteUrl = /** @type {string} */ (vars.siteUrl);
@@ -17,12 +17,12 @@ export default function sitemapTemplate ({ pages, vars }) {
     })
     .join('\n');
 
-  return [{
+  return {
     outputName: 'sitemap.xml',
     content: `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urls}
 </urlset>
 `,
-  }];
+  };
 }


### PR DESCRIPTION
Migrate the entire blog from Jekyll 3.8.6 to DomStack v11, a modern
Node.js static site generator built around esbuild with filesystem routing.

- Add DomStack project structure with src/ directory (117 pages)
- Migrate all 97 posts preserving exact URL structure (/:categories/:year/:month/:title/)
- Migrate 13 legacy redirect pages (2008-2011 year directories)
- Create root.layout.js and article.layout.js replacing Jekyll layouts
- Create render component library (src/lib/) replacing Jekyll includes
- Preserve all IndieWeb features: microformats2 (h-entry, h-card, h-feed),
  webmentions, indie-actions, micropub, WebSub/PubSubHubbub, rel-me
- Generate Atom feeds (all.xml, english.xml, links/all.xml) via template
- Generate sitemap.xml, robots.txt, manifest.json via templates
- Preserve PWA features (service worker, manifest, offline page)
- Follow voxpelli/node-app-template coding standards:
  ES modules, @voxpelli/eslint-config, types-in-JS, .editorconfig
- Remove Jekyll files (Gemfile, _config.yml, Travis CI)

https://claude.ai/code/session_01RmixQe4VVATyG7eZrQT4Uw